### PR TITLE
Add retry middleware to default_json_connection

### DIFF
--- a/lib/tn/http.rb
+++ b/lib/tn/http.rb
@@ -37,6 +37,7 @@ module TN
       default_connection(*arguments) do |conn|
         conn.response :mashify
         conn.response :json
+        conn.request :retry
         yield conn if block_given?
       end
     end


### PR DESCRIPTION
This will retry failed http requests twice (the faraday retry middleware default). Useful for channel_advisor failed api requests due to`[0] Channel Advisor networking error when posting products - Production TN::HTTP::ClientError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv3 read server session ticket A`.
